### PR TITLE
Use the same port on server with listen and response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@ mod file;
 pub mod packet;
 pub mod privilege;
 pub mod server;
+mod socket;
 pub mod temp;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use nix::sys::socket::{AddressFamily, InetAddr, SockAddr, SockFlag, SockType};
+use std::net::{SocketAddr, UdpSocket};
+use std::os::unix::io::{FromRawFd, RawFd};
+
+/// Factory method for std::net::UdpSocket.
+/// The inner socket has ReusePort and ReuseAddr options.
+/// This is necessary because UdpSocket itself doesn't allow set options before bind.
+pub fn create_udp_socket(addr: SocketAddr) -> Result<UdpSocket> {
+    let fd = nix::sys::socket::socket(
+        AddressFamily::Inet,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )?;
+    reuse_port(fd)?;
+    nix::sys::socket::bind(fd, &SockAddr::new_inet(InetAddr::from_std(&addr)))?;
+    unsafe { Ok(UdpSocket::from_raw_fd(fd)) }
+}
+
+fn reuse_port(fd: RawFd) -> Result<()> {
+    let opt = nix::sys::socket::sockopt::ReusePort;
+    nix::sys::socket::setsockopt(fd, opt, &true)?;
+    let opt = nix::sys::socket::sockopt::ReuseAddr;
+    nix::sys::socket::setsockopt(fd, opt, &true)?;
+    Ok(())
+}


### PR DESCRIPTION
The server uses the same port with the listening port to respond to clients.

The motivation of the change is it's friendly for firewalls. The original implementation assign new ports to respond to clients. However, most of clients have firewall rules which don't accept packets whose source address (and port) is unknown for them.

Note that this change might not be accordance with RFC. From [RFC1350](https://datatracker.ietf.org/doc/html/rfc1350),

> Every packet has associated with it the two TID's of the ends of the connection, the source TID and the destination TID.  These TID's are handed to the supporting UDP (or other datagram protocol) as the source and destination ports.  A requesting host chooses its source TID as described above, and sends its initial request to the known TID 69 decimal (105 octal) on the serving host.  The response to the request, under normal operation, uses a TID chosen by the server as its source TID and the TID chosen for the previous message by the requestor as its destination TID. The two chosen TID's are then used for the remainder of the transfer.